### PR TITLE
Fix dependency on java distribution

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -3,7 +3,8 @@ FROM gitpod/workspace-postgres:latest
 USER gitpod
 
 RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
-    && sdk default java 11.0.2-zulufx"
+    && sdk install java 11.0.5-open \
+    && sdk default java 11.0.5-open"
 
 RUN curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.4.2-darwin-x86_64.tar.gz --output elasticsearch-7.4.2.tar.gz \
     && tar -xzf elasticsearch-7.4.2.tar.gz

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -3,7 +3,6 @@ FROM gitpod/workspace-postgres:latest
 USER gitpod
 
 RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
-    && sdk install java 11.0.5-open \
     && sdk default java 11.0.5-open"
 
 RUN curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.4.2-darwin-x86_64.tar.gz --output elasticsearch-7.4.2.tar.gz \


### PR DESCRIPTION
The version distributed with `gitpod/workspace-full` changed from `11.0.2-zulufx` to `11.0.5-open`.